### PR TITLE
Fix BT Compile Error

### DIFF
--- a/middleware/bluetooth/Kconfig
+++ b/middleware/bluetooth/Kconfig
@@ -315,6 +315,4 @@ menu "Bluetooth"
     if !KCONFIG_V2 || KCONFIG_BOARD_V2
         rsource "Kconfig.hw"
     endif
-   
-    rsource "stack/zephyr_bt/Kconfig"
 endmenu


### PR DESCRIPTION
按照文档执行编译，会因为该Kconfig文件引用了一个不存在的配置导致编译报错