### PR TITLE
Add .gitignore, fix typo in scons scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/**/build_*
+/**/*.pyc
+.sconsign.dblite

--- a/example/ble/ams/project/common/SConstruct
+++ b/example/ble/ams/project/common/SConstruct
@@ -39,4 +39,4 @@ DoBuilding(TARGET, objs)
 # Add flash table
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/ble/central_and_peripheral/project/common/SConstruct
+++ b/example/ble/central_and_peripheral/project/common/SConstruct
@@ -44,4 +44,4 @@ DoBuilding(TARGET, objs)
 # Add flash table
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/ble/hid/project/common/SConstruct
+++ b/example/ble/hid/project/common/SConstruct
@@ -39,4 +39,4 @@ DoBuilding(TARGET, objs)
 # Add flash table
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/ble/peripheral/project/common/SConstruct
+++ b/example/ble/peripheral/project/common/SConstruct
@@ -57,4 +57,4 @@ DoBuilding(TARGET, objs)
 # Add flash table
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/boot_loader/project/butterflmicro/ram/SConstruct
+++ b/example/boot_loader/project/butterflmicro/ram/SConstruct
@@ -28,5 +28,5 @@ objs = PrepareBuilding(env)
 # make a building
 DoBuilding(TARGET, objs)
 
-GenDownloaScript(env)
+GenDownloadScript(env)
 

--- a/example/boot_loader/project/butterflmicro/ram_v2/SConstruct
+++ b/example/boot_loader/project/butterflmicro/ram_v2/SConstruct
@@ -30,5 +30,5 @@ objs = PrepareBuilding(env)
 # make a building
 DoBuilding(TARGET, objs)
 
-GenDownloaScript(env)
+GenDownloadScript(env)
 

--- a/example/boot_loader/project/sf32lb520/ram/SConstruct
+++ b/example/boot_loader/project/sf32lb520/ram/SConstruct
@@ -30,5 +30,5 @@ objs = PrepareBuilding(env)
 # make a building
 DoBuilding(TARGET, objs)
 
-GenDownloaScript(env)
+GenDownloadScript(env)
 

--- a/example/boot_loader/project/sf32lb56x_v2/SConstruct
+++ b/example/boot_loader/project/sf32lb56x_v2/SConstruct
@@ -30,5 +30,5 @@ objs = PrepareBuilding(env)
 # make a building
 DoBuilding(TARGET, objs)
 
-GenDownloaScript(env)
+GenDownloadScript(env)
 

--- a/example/boot_loader/project/sf32lb58x_v2/SConstruct
+++ b/example/boot_loader/project/sf32lb58x_v2/SConstruct
@@ -30,5 +30,5 @@ objs = PrepareBuilding(env)
 # make a building
 DoBuilding(TARGET, objs)
 
-GenDownloaScript(env)
+GenDownloadScript(env)
 

--- a/example/bt/test_example/project/common/SConstruct
+++ b/example/bt/test_example/project/common/SConstruct
@@ -40,4 +40,4 @@ DoBuilding(TARGET, objs)
 # Add flash table
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/get-started/blink/no-os/project/SConstruct
+++ b/example/get-started/blink/no-os/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/get-started/blink/rtt/project/SConstruct
+++ b/example/get-started/blink/rtt/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/get-started/hello_world/no-os/project/SConstruct
+++ b/example/get-started/hello_world/no-os/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/get-started/hello_world/rtt/project/SConstruct
+++ b/example/get-started/hello_world/rtt/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/adc/adc_battery/project/SConstruct
+++ b/example/hal/adc/adc_battery/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/aes/project/SConstruct
+++ b/example/hal/aes/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/crc/project/SConstruct
+++ b/example/hal/crc/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/ezip/project/SConstruct
+++ b/example/hal/ezip/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/gpio/project/SConstruct
+++ b/example/hal/gpio/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/hash/project/SConstruct
+++ b/example/hal/hash/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/hwtimer/project/SConstruct
+++ b/example/hal/hwtimer/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/i2c/eeprom/project/SConstruct
+++ b/example/hal/i2c/eeprom/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/pwm/project/SConstruct
+++ b/example/hal/pwm/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/rng/project/SConstruct
+++ b/example/hal/rng/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/rtc/project/SConstruct
+++ b/example/hal/rtc/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/spi/project/SConstruct
+++ b/example/hal/spi/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/tsen/project/SConstruct
+++ b/example/hal/tsen/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/uart/project/SConstruct
+++ b/example/hal/uart/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/wdt/iwdt/project/SConstruct
+++ b/example/hal/wdt/iwdt/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal/wdt/wdt1/project/SConstruct
+++ b/example/hal/wdt/wdt1/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/hal_example/project/common/SConstruct
+++ b/example/hal_example/project/common/SConstruct
@@ -37,4 +37,4 @@ DoBuilding(TARGET, objs)
 # Add flash table
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/misc/button/project/SConstruct
+++ b/example/misc/button/project/SConstruct
@@ -37,4 +37,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/multicore/data_service/common/hcpu/SConstruct
+++ b/example/multicore/data_service/common/hcpu/SConstruct
@@ -12,5 +12,5 @@ SIFLI_SDK = os.getenv('SIFLI_SDK')
 
 AddFTAB(SIFLI_SDK, rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)
 

--- a/example/multicore/ipc_queue/common/hcpu/SConstruct
+++ b/example/multicore/ipc_queue/common/hcpu/SConstruct
@@ -12,5 +12,5 @@ SIFLI_SDK = os.getenv('SIFLI_SDK')
 
 AddFTAB(SIFLI_SDK, rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)
 

--- a/example/multicore/rpmsg-lite/project/hcpu/SConstruct
+++ b/example/multicore/rpmsg-lite/project/hcpu/SConstruct
@@ -12,5 +12,5 @@ SIFLI_SDK = os.getenv('SIFLI_SDK')
 
 AddFTAB(SIFLI_SDK, rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)
 

--- a/example/multimedia/lvgl/lvgl_v8_demos/project/SConstruct
+++ b/example/multimedia/lvgl/lvgl_v8_demos/project/SConstruct
@@ -37,4 +37,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/multimedia/lvgl/lvgl_v8_examples/project/SConstruct
+++ b/example/multimedia/lvgl/lvgl_v8_examples/project/SConstruct
@@ -37,4 +37,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/multimedia/lvgl/lvgl_v9_demos/project/SConstruct
+++ b/example/multimedia/lvgl/lvgl_v9_demos/project/SConstruct
@@ -37,4 +37,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/multimedia/lvgl/lvgl_v9_examples/project/SConstruct
+++ b/example/multimedia/lvgl/lvgl_v9_examples/project/SConstruct
@@ -37,4 +37,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/multimedia/lvgl/watch/project/SConstruct
+++ b/example/multimedia/lvgl/watch/project/SConstruct
@@ -37,4 +37,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/pm/ble/common/hcpu/SConstruct
+++ b/example/pm/ble/common/hcpu/SConstruct
@@ -39,5 +39,5 @@ DoBuilding(TARGET, objs)
 
 AddFTAB(SIFLI_SDK, rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)
 

--- a/example/pm/bt/project/common/hcpu/SConstruct
+++ b/example/pm/bt/project/common/hcpu/SConstruct
@@ -12,5 +12,5 @@ SIFLI_SDK = os.getenv('SIFLI_SDK')
 
 AddFTAB(SIFLI_SDK, rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)
 

--- a/example/pm/coremark/common/hcpu/SConstruct
+++ b/example/pm/coremark/common/hcpu/SConstruct
@@ -12,5 +12,5 @@ SIFLI_SDK = os.getenv('SIFLI_SDK')
 
 AddFTAB(SIFLI_SDK, rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)
 

--- a/example/printer/project/SConstruct
+++ b/example/printer/project/SConstruct
@@ -63,4 +63,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_device/adc/adc_battery/project/SConstruct
+++ b/example/rt_device/adc/adc_battery/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_device/i2c/eeprom/project/SConstruct
+++ b/example/rt_device/i2c/eeprom/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_device/pwm/project/SConstruct
+++ b/example/rt_device/pwm/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_device/rgb_led/project/SConstruct
+++ b/example/rt_device/rgb_led/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_device/rtc/project/SConstruct
+++ b/example/rt_device/rtc/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_device/spi/card/project/SConstruct
+++ b/example/rt_device/spi/card/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_device/spi/flash/project/SConstruct
+++ b/example/rt_device/spi/flash/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_device/uart/project/SConstruct
+++ b/example/rt_device/uart/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_device/usb/usb_mstorage/project/SConstruct
+++ b/example/rt_device/usb/usb_mstorage/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_device/usb/usb_vcom/project/SConstruct
+++ b/example/rt_device/usb/usb_vcom/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_device/wdt/project/SConstruct
+++ b/example/rt_device/wdt/project/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/rt_driver/project/SConstruct
+++ b/example/rt_driver/project/SConstruct
@@ -37,4 +37,4 @@ DoBuilding(TARGET, objs)
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
 # Generate download .bat script
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/uart/project/common/SConstruct
+++ b/example/uart/project/common/SConstruct
@@ -38,4 +38,4 @@ DoBuilding(TARGET, objs)
 # Add flash table
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/tools/build/building.py
+++ b/tools/build/building.py
@@ -487,7 +487,7 @@ def AddCustomImg(name, hex = None, bin = None):
 def GetCustomImgList():
     return CustomImgList
 
-def GenDownloaScript(main_env):
+def GenDownloadScript(main_env):
     import resource
     
     PrintEnvList()


### PR DESCRIPTION
增加了`.gitignore`来排除构建时产生的文件，修了一个在Scons构建脚本中的`GenDownloaScript` typo