### PR TITLE
Remove duplicate `FLASH_BOOT_LOADER` tag in ptab.json for lb52 boards

### DIFF
--- a/customer/boards/eh-lb520/ptab.json
+++ b/customer/boards/eh-lb520/ptab.json
@@ -15,9 +15,7 @@
             {
                 "offset": "0x00008000", 
                 "max_size": "0x00010000", 
-                "tags": [
-                    "FLASH_BOOT_LOADER"
-                ], 
+                "tags": [], 
                 "ftab": {
                     "name": "bootloader", 
                     "address": [

--- a/customer/boards/eh-lb520S/ptab.json
+++ b/customer/boards/eh-lb520S/ptab.json
@@ -15,9 +15,7 @@
             {
                 "offset": "0x00003000", 
                 "max_size": "0x00004000", 
-                "tags": [
-                    "FLASH_BOOT_LOADER"
-                ], 
+                "tags": [], 
                 "ftab": {
                     "name": "bootloader", 
                     "address": [

--- a/customer/boards/eh-lb523/ptab.json
+++ b/customer/boards/eh-lb523/ptab.json
@@ -15,9 +15,7 @@
             {
                 "offset": "0x00010000", 
                 "max_size": "0x00010000", 
-                "tags": [
-                    "FLASH_BOOT_LOADER"
-                ], 
+                "tags": [], 
                 "ftab": {
                     "name": "bootloader", 
                     "address": [

--- a/customer/boards/eh-ss6500/ptab.json
+++ b/customer/boards/eh-ss6500/ptab.json
@@ -15,9 +15,7 @@
             {
                 "offset": "0x00008000", 
                 "max_size": "0x00010000", 
-                "tags": [
-                    "FLASH_BOOT_LOADER"
-                ], 
+                "tags": [], 
                 "ftab": {
                     "name": "bootloader", 
                     "address": [

--- a/customer/boards/em-lb525/ptab.json
+++ b/customer/boards/em-lb525/ptab.json
@@ -15,9 +15,7 @@
             {
                 "offset": "0x00010000", 
                 "max_size": "0x00010000", 
-                "tags": [
-                    "FLASH_BOOT_LOADER"
-                ], 
+                "tags": [],
                 "ftab": {
                     "name": "bootloader", 
                     "address": [


### PR DESCRIPTION
删除了lb52板子的ptab.json重复的FLASH_BOOT_LOADER，避免重复宏生成

经过测试，不会影响 ftab.bin 的内容

Closes: https://github.com/OpenSiFli/SiFli-SDK/issues/10