### PR TITLE
Fix #6 typo in new examples

### DIFF
--- a/example/bt/hfp/project/SConstruct
+++ b/example/bt/hfp/project/SConstruct
@@ -40,4 +40,4 @@ DoBuilding(TARGET, objs)
 # Add flash table
 AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 
-GenDownloaScript(env)
+GenDownloadScript(env)

--- a/example/bt/music_source/project/SConstruct
+++ b/example/bt/music_source/project/SConstruct
@@ -44,4 +44,4 @@ AddFTAB(SIFLI_SDK,rtconfig.CHIP)
 fs_bin=FileSystemBuild( "../disk", env)
 AddCustomImg("fs_root",bin=[fs_bin])
 
-GenDownloaScript(env)
+GenDownloadScript(env)


### PR DESCRIPTION
2.3.1新增的两个example中存在 #6 的typo，导致编译出错，可能是在同步git时出的问题