### PR TITLE
Add VS Code DevContainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:22.04 AS core
+
+# Install all dependencies
+RUN apt-get update && apt-get install -y \
+    sudo git wget flex bison gperf \
+    python3 python3-pip python3-venv \
+    cmake ninja-build ccache \
+    libffi-dev libssl-dev \
+    dfu-util libusb-1.0-0 \
+    && apt-get clean
+
+# Create a sifli user with sudo
+ARG USERNAME=sifli
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME && \
+    useradd --gid $USER_GID --uid $USER_UID --shell /bin/bash --create-home $USERNAME && \
+    usermod -aG sudo $USERNAME && \
+    echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# ~~~~~~~~~~ ~~~~~~~~~~ ~~~~~~~~~~ ~~~~~~~~~~ ~~~~~~~~~~
+
+FROM core AS toolchain
+
+# Install the toolchain
+COPY install.sh /home/sifli/src/install.sh
+COPY tools /home/sifli/src/tools
+COPY version.txt /home/sifli/src/version.txt
+
+RUN sudo --user=sifli /home/sifli/src/install.sh
+
+# ~~~~~~~~~~ ~~~~~~~~~~ ~~~~~~~~~~ ~~~~~~~~~~ ~~~~~~~~~~
+
+FROM core AS devcontainer
+
+# Install the toolchain
+COPY --from=toolchain /home/sifli/.sifli /home/sifli/.sifli
+
+COPY .devcontainer/motd /etc/motd
+RUN chmod +x /etc/motd && \
+    echo "alias init='source /home/sifli/src/export.sh'" >> /home/sifli/.bashrc && \
+    echo '[ ! -z "$TERM" -a -r /etc/motd ] && /etc/motd' >> /home/sifli/.bashrc && \
+    echo '[ -f /home/sifli/src/export.sh ] && source /home/sifli/src/export.sh' >> /home/sifli/.bashrc && \
+    touch /home/sifli/.sudo_as_admin_successful
+
+USER sifli
+WORKDIR /home/sifli/src
+ENV TERM=xterm-256color

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "name": "SiFli SDK Embedded DevContainer",
+    "build":
+    {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "mounts":
+    [
+        "source=${localWorkspaceFolder},target=/home/sifli/src,type=bind,consistency=cached"
+    ],
+    "workspaceFolder": "/home/sifli/src",
+    "shutdownAction": "stopContainer",
+    "remoteUser": "sifli"
+}

--- a/.devcontainer/motd
+++ b/.devcontainer/motd
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GREEN='\e[32m'
+ORANGE='\e[38;5;208m'
+BOLD='\e[1m'
+RESET='\e[0m'
+
+echo -e "${BOLD}${ORANGE}🎉 Welcome, to SIFLI-SDK Dev Container! 👋${RESET}"
+echo " "
+echo "To load your SIFLI SDK environment, please run:"
+echo -e " ${ORANGE}*${RESET} Cmd: ${GREEN}source export.sh${RESET} Or"
+echo -e " ${ORANGE}*${RESET} Cmd: ${GREEN}init${RESET}"
+echo " "
+echo "After sourcing, you can either start a shell or begin your build, e.g.:"
+echo -e " ${ORANGE}*${RESET} Cmd: ${GREEN}cd example/get-started/hello_world/rtt/project/${RESET}"
+echo -e " ${ORANGE}*${RESET} Cmd: ${GREEN}scons --board=ec-lb587 -j16${RESET}"
+echo " "

--- a/export.sh
+++ b/export.sh
@@ -65,7 +65,6 @@ fi
 sdk_exports=$("$SIFLI_PYTHON" "${sdk_path}/tools/activate.py" --export --shell $shell_type)
 eval "${sdk_exports}"
 unset sdk_path
-return 0
 
-# SDK 2.x
-
+# Fix RTT_EXEC_PATH
+export RTT_EXEC_PATH="${PATH}"

--- a/middleware/dfu/sec_flash.c
+++ b/middleware/dfu/sec_flash.c
@@ -268,7 +268,7 @@ int sec_flash_read(int flashid, uint32_t offset, uint8_t *data, uint32_t size)
 
 void sec_flash_init()
 {
-    uint32_t start_addr = NULL;
+    uint32_t start_addr = 0;
     uint8_t is_enable = flash_is_enabled(0);
 
     // Boot order will be : flash1 -> flash2


### PR DESCRIPTION
This pull request adds `.devcontainer/Dockerfile` and `.devcontainer/devcontainer.json` so contributors can launch a pre-configured development container in VS Code with all toolchain dependencies installed.

----

### How to Test VS Code DevContainer

1. Install Docker  
2. Install VS Code Remote – Containers extension  
3. Open this repo in VS Code  
4. Run **Remote-Containers: Reopen in Container**  
5. Open a terminal in the container and verify:

``` bash
# should have SiFli SDK tools installed and exported
scons --board=ec-lb587 -j16 -C example/get-started/hello_world/rtt/project/
```

### Use Docker without VS Code

``` bash
# Build the Docker 'toolchain' image using the Dockerfile at .devcontainer/Dockerfile
docker build -f .devcontainer/Dockerfile . -t toolchain

# Run the 'toolchain' container interactively with the current directory mounted to /home/sifli/src and execute the SCons build
docker run -it --rm -v ${PWD}:/home/sifli/src toolchain \
  /bin/bash -ic "scons --board=ec-lb587 -j16 -C example/get-started/hello_world/rtt/project/"
```