### PR TITLE
feat: enhance UART download script with smart port selection

### DIFF
--- a/tools/build/resource.py
+++ b/tools/build/resource.py
@@ -1770,14 +1770,67 @@ cd %CURR_PATH%
 def generate_uart_download_sh(main_env, device, memory,download_list):
     uart_comment = '''#!/bin/bash
 
-WORK_PATH=$(dirname "$0")
-CURR_PATH=$(pwd)
+WORK_PATH="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd)"
 cd "$WORK_PATH"
 
 echo ""
 echo "      Uart Download"
 echo ""
-read -p "please input the serial port (e.g. /dev/ttyUSB0): " input
+
+input=""
+if [ $# -gt 0 ]; then
+  case "$1" in
+    -p|--port)
+      shift
+      input="${1:-}"
+      ;;
+    *)
+      input="$1"
+      ;;
+  esac
+fi
+
+if [ -n "$input" ]; then
+  # Port provided as argument
+  echo "Using port from args: $input"
+else
+  # If no port is specified, enumerate available ports
+  ports=()
+  unameOut="$(uname)"
+  if [ "$unameOut" = "Darwin" ]; then
+    for p in /dev/cu.*; do
+      if [ -e "$p" ] && echo "$p" | grep -qi "usb"; then
+        ports+=("$p")
+      fi
+    done
+  elif [ "$unameOut" = "Linux" ]; then
+    for p in /dev/ttyUSB* /dev/ttyACM*; do
+      [ -e "$p" ] && ports+=("$p")
+    done
+  else
+    echo "Unsupported OS: $unameOut"
+    exit 1
+  fi
+
+  if [ "${#ports[@]}" -gt 0 ]; then
+    echo "Available serial ports:"
+    for i in "${!ports[@]}"; do
+      printf "  [%d] %s\n" "$i" "${ports[$i]}"
+    done
+  else
+    echo "No ports auto-detected."
+  fi
+
+  read -r -p "Enter index OR type a port (e.g. /dev/ttyUSB0): " sel
+  if [[ "$sel" =~ ^[0-9]+$ ]] && [ "$sel" -ge 0 ] && [ "$sel" -lt "${#ports[@]}" ]; then
+    # Index provided
+    input="${ports[$sel]}"
+  else
+    # Assume direct port input, the old way
+    input="$sel"
+  fi
+fi
+
 echo "$input"
 
 '''


### PR DESCRIPTION
- Auto-detect available serial ports on Linux and macOS
- Support command-line arguments for port specification (-p/--port)
- Add indexed port selection for better user experience
- Improve cross-platform compatibility (Darwin/Linux)
- Provide fallback for manual port input
- Fix working directory handling in shell script

This update significantly improves the user experience by automatically discovering available USB serial ports and providing an intuitive selection interface, while maintaining backward compatibility with manual port specification.

TEST:
Use the "-p" keyword to specify the port
```bash
$ ./build_sf32lb52-lchspi-ulp_hcpu/uart_download.sh -p /dev/cu.usbserial-2130

      Uart Download

Using port from args: /dev/cu.usbserial-2130
/dev/cu.usbserial-2130
[0x00]   Connected success!                                                                         
[0x01]   Download stub success!                                                                     
[0x02]   No need to re-download, skip!                                                              
[0x03]   Need to re-download                                                                        
[0x04] Download success! ====================================================== 85.62 KiB/s 100.000%
[0x05]   Verify success!                                                                            
[0x06]   Need to re-download                                                                        
[0x07] Download success! ====================================================== 52.70 KiB/s 100.000%
[0x08]   Verify success! 
```
Specifying a port without using a keyword
```bash
$ ./build_sf32lb52-lchspi-ulp_hcpu/uart_download.sh /dev/cu.usbserial-2130

      Uart Download

Using port from args: /dev/cu.usbserial-2130
/dev/cu.usbserial-2130
[0x00]   Connected success!                                                                         
[0x01]   Download stub success!                                                                     
[0x02]   No need to re-download, skip!                                                              
[0x03]   Need to re-download                                                                        
[0x04] Download success! ====================================================== 84.72 KiB/s 100.000%
[0x05]   Verify success!                                                                            
[0x06]   Need to re-download                                                                        
[0x07] Download success! ====================================================== 52.29 KiB/s 100.000%
[0x08]   Verify success!   
```
Select a port using an enumerated number
```bash
$ ./build_sf32lb52-lchspi-ulp_hcpu/uart_download.sh

      Uart Download

Available serial ports:
  [0] /dev/cu.usbmodem212101
  [1] /dev/cu.usbserial-2130
  [2] /dev/cu.wchusbserial2130
Enter index OR type a port (e.g. /dev/ttyUSB0): 1
/dev/cu.usbserial-2130
[0x00]   Connected success!                                                                         
[0x01]   Download stub success!                                                                     
[0x02]   No need to re-download, skip!                                                              
[0x03]   Need to re-download                                                                        
[0x04] Download success! ====================================================== 85.55 KiB/s 100.000%
[0x05]   Verify success!                                                                            
[0x06]   Need to re-download                                                                        
[0x07] Download success! ====================================================== 52.56 KiB/s 100.000%
[0x08]   Verify success!   
```
Compatible with the old method, manually enter the port
```bash
$ ./build_sf32lb52-lchspi-ulp_hcpu/uart_download.sh

      Uart Download

Available serial ports:
  [0] /dev/cu.usbmodem212101
  [1] /dev/cu.usbserial-2130
  [2] /dev/cu.wchusbserial2130
Enter index OR type a port (e.g. /dev/ttyUSB0): /dev/cu.usbserial-2130
/dev/cu.usbserial-2130
[0x00]   Connected success!                                                                         
[0x01]   Download stub success!                                                                     
[0x02]   No need to re-download, skip!                                                              
[0x03]   Need to re-download                                                                        
[0x04] Download success! ====================================================== 84.79 KiB/s 100.000%
[0x05]   Verify success!                                                                            
[0x06]   Need to re-download                                                                        
[0x07] Download success! ====================================================== 52.43 KiB/s 100.000%
[0x08]   Verify success!                                                                            
```
