### PR TITLE
[DNM] drivers/lcdc: update jdi driver

### DIFF
--- a/drivers/hal/bf0_hal_lcdc.c
+++ b/drivers/hal/bf0_hal_lcdc.c
@@ -1554,7 +1554,7 @@ static HAL_StatusTypeDef _SendLayerData(LCDC_HandleTypeDef *lcdc, LCDC_AsyncMode
 
         /* Interrupt after send half of 'max_line' data */
         lcdc->Instance->JDI_PAR_CTRL &= ~LCD_IF_JDI_PAR_CTRL_INT_LINE_NUM_Msk;
-        lcdc->Instance->JDI_PAR_CTRL |= ((max_line / 2) - 1) << LCD_IF_JDI_PAR_CTRL_INT_LINE_NUM_Pos;
+        lcdc->Instance->JDI_PAR_CTRL |= max_line << LCD_IF_JDI_PAR_CTRL_INT_LINE_NUM_Pos;
 
         lcdc->Instance->SETTING |= LCD_IF_SETTING_JDI_PARL_INTR_MASK | LCD_IF_SETTING_EOF_MASK;
         //Pull up rst


### PR DESCRIPTION
This PR try to reduce the jdi display update time to 1fps.

WRONG: ~jdi display frequency normally set to 60 fps. Current jdi display update spend 2 fps, nearly 30ms. This heavily reduced the jdi display performance.~

Not stable yet, introduce new display issue, dislay is flashing.
