### PR TITLE
Add 'PowerShell.exe' to shell_types.py to enhance compatibility

### DIFF
--- a/tools/export_utils/shell_types.py
+++ b/tools/export_utils/shell_types.py
@@ -335,6 +335,7 @@ SHELL_CLASSES = {
     'nu': UnixShell,
     'pwsh.exe': PowerShell,
     'pwsh': PowerShell,
+    'PowerShell.exe': PowerShell, 
     'powershell.exe': PowerShell,
     'powershell': PowerShell,
     'cmd.exe': WinCmd,


### PR DESCRIPTION
Adding compatibility for the "Activation script failed" error when running export.ps1 with a non-recommended version of PowerShell.
<img width="1329" height="396" alt="mmexport1764404879258" src="https://github.com/user-attachments/assets/8ac03f6f-6a69-4933-b4db-f91597004959" />
![mmexport1764404881431](https://github.com/user-attachments/assets/e7a713ab-d416-4596-9b3b-535c3d4fb220)
