### PR TITLE
[fix][example][multimedia]Fix readme example code

### DIFF
--- a/example/multimedia/lvgl/ezip/README.md
+++ b/example/multimedia/lvgl/ezip/README.md
@@ -106,8 +106,11 @@ set_image A:/example.ezip file
 # 从SD卡加载（LVGL V8）
 set_image /sdcard/image.ezip dsc sram
 
-# 从SD卡加载（LVGL V9，注意需要 A: 前缀）
-set_image A:/sdcard/image.ezip dsc sram
+# 从SD卡预先加载到内存（LVGL V9 不需要A: 前缀）
+set_image /sdcard/image.ezip dsc sram
+
+# 从SD卡直接加载（LVGL V9 注意需要 A: 前缀）
+set_image A:/sdcard/image.ezip file
 ```
 
 ## API说明

--- a/example/multimedia/lvgl/ezip/README_EN.md
+++ b/example/multimedia/lvgl/ezip/README_EN.md
@@ -106,8 +106,11 @@ set_image A:/example.ezip file
 # Load from SD card (LVGL V8)
 set_image /sdcard/image.ezip dsc sram
 
-# Load from SD card (LVGL V9, note the A: prefix required)
-set_image A:/sdcard/image.ezip dsc sram
+# Preload from the SD card to the sram (LVGL V9, note: A: prefix is not required)
+set_image /sdcard/image.ezip dsc sram
+
+# Load from SD card (LVGL V9, note: A: prefix required)
+set_image A:/sdcard/image.ezip dsc file
 ```
 
 ## API Reference

--- a/example/multimedia/lvgl/ezip_v9/README.md
+++ b/example/multimedia/lvgl/ezip_v9/README.md
@@ -106,8 +106,11 @@ set_image A:/example.ezip file
 # 从SD卡加载（LVGL V8）
 set_image /sdcard/image.ezip dsc sram
 
-# 从SD卡加载（LVGL V9，注意需要 A: 前缀）
-set_image A:/sdcard/image.ezip dsc sram
+# 从SD卡预先加载到内存（LVGL V9 不需要A: 前缀）
+set_image /sdcard/image.ezip dsc sram
+
+# 从SD卡直接加载（LVGL V9 注意需要 A: 前缀）
+set_image A:/sdcard/image.ezip file
 ```
 
 ## API说明

--- a/example/multimedia/lvgl/ezip_v9/README_EN.md
+++ b/example/multimedia/lvgl/ezip_v9/README_EN.md
@@ -106,8 +106,11 @@ set_image A:/example.ezip file
 # Load from SD card (LVGL V8)
 set_image /sdcard/image.ezip dsc sram
 
+# Preload from the SD card to the sram (LVGL V9, note: A: prefix is not required)
+set_image /sdcard/image.ezip dsc sram
+
 # Load from SD card (LVGL V9, note: A: prefix required)
-set_image A:/sdcard/image.ezip dsc sram
+set_image A:/sdcard/image.ezip dsc file
 ```
 
 ## API Description


### PR DESCRIPTION
After testing, we found that in the original README, the line:
```c
Load from SD card (LVGL V9, note the A: prefix)
set_image A:/sdcard/image.ezip dsc sram
```
does not require the prefix.

Test result  
Yellow area faild！
White area success！



<img width="1624" height="968" alt="ac1a1283b342b0a878e5d30d37701b2e" src="https://github.com/user-attachments/assets/022852d3-923e-403f-b78d-639b61327437" />

![result](https://github.com/user-attachments/assets/47873c54-93de-4d80-8761-a6b92e7b5ca1)


