### PR TITLE
[opt][uart_download] Support get download baud rate form SIFLI_DOWNLOAD_BAUD_RATE environment variable.

### DIFF
--- a/tools/build/sdk_resource.py
+++ b/tools/build/sdk_resource.py
@@ -1788,6 +1788,14 @@ def BuildJLinkLoadScript(main_env):
     generate_uart_download_sh(main_env, device, memory, download_list)
     generate_sftool_param(main_env, device, memory, download_file)
 
+def get_baud_rate():
+    baud_rate = os.getenv("SIFLI_DOWNLOAD_BAUD_RATE", "").strip()
+    if baud_rate.isdigit():
+        rate_num = int(baud_rate)
+        if 115200 <= rate_num <= 3000000:
+            return f"-b {rate_num}"
+    return ""
+
 
 def generate_uart_download_bat(main_env, device, memory, download_list, ImgDownUart_PATH):
     uart_comment = '''@echo off
@@ -1815,7 +1823,7 @@ if %errorlevel%==0 (
 cd %CURR_PATH%
 '''.format(ImgDownUart_PATH, main_env['JLINK_DEVICE']))
     else:
-        uart_comment += MakeLine(f"sftool -p COM%input% -c {device} -m {memory.lower()} write_flash {download_list}\n")
+        uart_comment += MakeLine(f"sftool -p COM%input% {get_baud_rate()} -c {device} -m {memory.lower()} write_flash {download_list}\n")
     uart_comment += MakeLine('if "%ENV_ROOT%"=="" pause\n')
     
     uart_f = open(os.path.join(main_env['build_dir'], 'uart_download.bat'), 'w')
@@ -1893,7 +1901,7 @@ echo "$input"
     if os.getenv("LEGACY_ENV"):
         uart_comment += MakeLine('echo "Legacy mode is not supported on Linux/macOS"')
     else:
-        uart_comment += MakeLine(f'sftool -p "$input" -c {device} -m {memory.lower()} write_flash {download_list}\n')
+        uart_comment += MakeLine(f'sftool -p "$input" {get_baud_rate()} -c {device} -m {memory.lower()} write_flash {download_list}\n')
     
     uart_sh_path = os.path.join(main_env['build_dir'], 'uart_download.sh')
     uart_f = open(uart_sh_path, 'w')

--- a/tools/build/sdk_resource.py
+++ b/tools/build/sdk_resource.py
@@ -2184,6 +2184,14 @@ def BuildJLinkLoadScript(main_env):
     generate_uart_download_sh(main_env, device, memory, download_list)
     generate_sftool_param(main_env, device, memory, download_file)
 
+def get_baud_rate():
+    baud_rate = os.getenv("SIFLI_DOWNLOAD_BAUD_RATE", "").strip()
+    if baud_rate.isdigit():
+        rate_num = int(baud_rate)
+        if 115200 <= rate_num <= 3000000:
+            return f"-b {rate_num}"
+    return ""
+
 
 def generate_uart_download_bat(main_env, device, memory, download_list, ImgDownUart_PATH):
     uart_comment = '''@echo off
@@ -2211,7 +2219,7 @@ if %errorlevel%==0 (
 cd %CURR_PATH%
 '''.format(ImgDownUart_PATH, main_env['JLINK_DEVICE']))
     else:
-        uart_comment += MakeLine(f"sftool -p COM%input% -c {device} -m {memory.lower()} write_flash {download_list}\n")
+        uart_comment += MakeLine(f"sftool -p COM%input% {get_baud_rate()} -c {device} -m {memory.lower()} write_flash {download_list}\n")
     uart_comment += MakeLine('if "%ENV_ROOT%"=="" pause\n')
     
     uart_f = open(os.path.join(main_env['build_dir'], 'uart_download.bat'), 'w')
@@ -2289,7 +2297,7 @@ echo "$input"
     if os.getenv("LEGACY_ENV"):
         uart_comment += MakeLine('echo "Legacy mode is not supported on Linux/macOS"')
     else:
-        uart_comment += MakeLine(f'sftool -p "$input" -c {device} -m {memory.lower()} write_flash {download_list}\n')
+        uart_comment += MakeLine(f'sftool -p "$input" {get_baud_rate()} -c {device} -m {memory.lower()} write_flash {download_list}\n')
     
     uart_sh_path = os.path.join(main_env['build_dir'], 'uart_download.sh')
     uart_f = open(uart_sh_path, 'w')

--- a/tools/sdk_py_actions/flash_ext.py
+++ b/tools/sdk_py_actions/flash_ext.py
@@ -169,8 +169,16 @@ def flash_callback(
 
     raise UsageError(f"Unsupported protocol: {protocol}")
 
+def get_baud_rate():
+    baud_rate = os.getenv("SIFLI_DOWNLOAD_BAUD_RATE", "").strip()
+    if baud_rate.isdigit():
+        rate_num = int(baud_rate)
+        if 115200 <= rate_num <= 3000000:
+            return rate_num
+    return 1000000
 
 def register(registry: CommandRegistry) -> None:
+    baud = get_baud_rate()
     registry.command(
         path="flash",
         callback=flash_callback,
@@ -192,7 +200,7 @@ def register(registry: CommandRegistry) -> None:
                 "names": ["-b", "--baud"],
                 "help": "Baud rate for UART flash.",
                 "type": int,
-                "default": 1000000,
+                "default": baud,
             },
             {
                 "names": ["-d", "--device"],


### PR DESCRIPTION
To increase uart download speed, when generate uart_download.bat/uart_download.sh read `SIFLI_DOWNLOAD_BAUD_RATE` and set to sftool.

useage:

Linux/Mac
```bash
export SIFLI_DOWNLOAD_BAUD_RATE=3000000
```

powershell
```powershell
$env:SIFLI_DOWNLOAD_BAUD_RATE=3000000
```

Windows CMD
```cmd
set SIFLI_DOWNLOAD_BAUD_RATE=3000000
```


| UART 波特率 | 传输速度    |
|------------|-------------|
| 3M         | 188.85 KiB/s |
| 2M         | 139.76 KiB/s |
| 1M         | 85.09 KiB/s  |
