### PR TITLE
[bug][drv_lcd] set the LCDC layer pixel format when the LCD is opened

### DIFF
--- a/rtos/rtthread/bsp/sifli/drivers/drv_lcd.c
+++ b/rtos/rtthread/bsp/sifli/drivers/drv_lcd.c
@@ -720,6 +720,25 @@ static rt_err_t lcd_hw_open(void)
 
     if (drv_lcd.p_drv_ops)
     {
+        /*
+            The graphic device draw APIs (set_pixel/draw_rect/draw_rect_async)
+            carry no pixel format: by the RT-Thread graphic device contract the
+            caller's buffer uses the format reported by RTGRAPHIC_CTRL_GET_INFO,
+            which is the LCD's configured colour mode. Program the LCDC layer
+            with that format here.
+
+            Without this the layer format keeps the value HAL_LCDC_Init() leaves
+            it at, LCDC_PIXEL_FORMAT_MONO(0), for every LCD driver that does not
+            call HAL_LCDC_LayerSetFormat() itself, and the first draw_rect()
+            asserts in HAL_LCDC_GetPixelSize(). SF_GRAPHIC_CTRL_LCDC_FLUSH still
+            overrides the layer format on every flush.
+        */
+        const LCDC_InitTypeDef *lcd_cfg = drv_lcd.p_drv_ops->p_init_cfg;
+
+        drv_lcd.buf_format = hal_lcd_format_to_rt_lcd_format(lcd_cfg->color_mode);
+        HAL_LCDC_LayerSetFormat(&drv_lcd.hlcdc, drv_lcd.select_layer,
+                                lcd_cfg->color_mode);
+
         enable_low_power(&drv_lcd);
 
 #ifdef DRV_LCD_USE_LCDC1

--- a/rtos/rtthread/bsp/sifli/drivers/drv_lcd_private.c
+++ b/rtos/rtthread/bsp/sifli/drivers/drv_lcd_private.c
@@ -173,6 +173,39 @@ HAL_LCDC_PixelFormat rt_lcd_format_to_hal_lcd_format(uint16_t rt_color_format)
 
 }
 
+uint16_t hal_lcd_format_to_rt_lcd_format(HAL_LCDC_PixelFormat hal_color_format)
+{
+    switch (hal_color_format)
+    {
+    case LCDC_PIXEL_FORMAT_MONO:
+        return RTGRAPHIC_PIXEL_FORMAT_MONO;
+
+    case LCDC_PIXEL_FORMAT_RGB332:
+        return RTGRAPHIC_PIXEL_FORMAT_RGB332;
+    case LCDC_PIXEL_FORMAT_RGB565:
+        return RTGRAPHIC_PIXEL_FORMAT_RGB565;
+    case LCDC_PIXEL_FORMAT_RGB666:
+        return RTGRAPHIC_PIXEL_FORMAT_RGB666;
+    case LCDC_PIXEL_FORMAT_RGB888:
+        return RTGRAPHIC_PIXEL_FORMAT_RGB888;
+    case LCDC_PIXEL_FORMAT_ARGB888:
+        return RTGRAPHIC_PIXEL_FORMAT_ARGB888;
+    case LCDC_PIXEL_FORMAT_ARGB565:
+        return RTGRAPHIC_PIXEL_FORMAT_ARGB565;
+
+    case LCDC_PIXEL_FORMAT_A4:
+        return RTGRAPHIC_PIXEL_FORMAT_GRAY4;
+    case LCDC_PIXEL_FORMAT_A8:
+        return RTGRAPHIC_PIXEL_FORMAT_A8;
+    case LCDC_PIXEL_FORMAT_L8:
+        return RTGRAPHIC_PIXEL_FORMAT_L8;
+
+    default:
+        RT_ASSERT(0); //unknow format
+        return 0;
+    }
+
+}
 
 
 rt_err_t rt_lcd_layer_control(LCD_DrvTypeDef *p_drv_lcd, int cmd, void *args)

--- a/rtos/rtthread/bsp/sifli/drivers/drv_lcd_private.h
+++ b/rtos/rtthread/bsp/sifli/drivers/drv_lcd_private.h
@@ -175,6 +175,7 @@ typedef struct
 
 
 HAL_LCDC_PixelFormat rt_lcd_format_to_hal_lcd_format(uint16_t rt_color_format);
+uint16_t hal_lcd_format_to_rt_lcd_format(HAL_LCDC_PixelFormat hal_color_format);
 rt_err_t rt_lcd_layer_control(LCD_DrvTypeDef *p_drv_lcd, int cmd, void *args);
 
 #endif /* __DRV_LCD_PRIVATE_H__ */


### PR DESCRIPTION
## Problem

The RT-Thread graphic device draw ops exposed by `drv_lcd` — `set_pixel`, `draw_rect`, `draw_rect_async` — take no pixel format argument. By the graphic device contract the caller's buffer is in the format reported by `RTGRAPHIC_CTRL_GET_INFO`, which `drv_lcd` derives from the LCD driver's configured colour mode. Nothing was programming the LCDC layer with that format.

`HAL_LCDC_Init()` does not initialise `Layer[].data_format`, and the handle lives in a zero-initialised static, so the layer format stays `LCDC_PIXEL_FORMAT_MONO(0)` unless the panel driver sets it itself. Most panel drivers under `customer/peripherals/display` do not — 31 of them never call `HAL_LCDC_LayerSetFormat()` at all, and `co5300` only calls it from `LCD_Clear()`, which has no callers.

The only place that ever set the layer format was the `SF_GRAPHIC_CTRL_LCDC_FLUSH` handler. So on those panels the first `draw_rect()` that is not preceded by a flush reaches `HAL_LCDC_GetPixelSize()` with `LCDC_PIXEL_FORMAT_MONO`, which has no case for it, and trips the `HAL_ASSERT(0)` in its `default:` branch — taking down `lcd_task`:

```
HAL assertion failed in file:...\drivers\hal\bf0_hal_lcdc.c, line number:207
Assertion failed at function:HAL_AssertFailed, line number:591 ,(0)
...
fatal error on thread: lcd_task
```

This is easy to hit: an application that renders its own framebuffer and pushes it with the documented graphic device API, without going through LVGL or `drv_lcd_fb`, crashes on its very first frame.

## Fix

Program the LCDC layer format from the LCD's colour mode in `lcd_hw_open()`, once the panel driver has been found and initialised. Also seed `drv_lcd.buf_format` from the same value, so the `COPY2COMPRESS` and `BSP_USE_LCDC2_ON_HPSYS` copy paths do not start out on an unset format either.

`SF_GRAPHIC_CTRL_LCDC_FLUSH` keeps overriding both on every flush, so LVGL and `drv_lcd_fb` behaviour is unchanged.

Adds `hal_lcd_format_to_rt_lcd_format()`, the inverse of the existing `rt_lcd_format_to_hal_lcd_format()`.

## Testing

Tested on an SF32LB52-DevKit-LCD (`--board=sf32lb52-lcd_n16r8`) with a 390x450 CO5300 AMOLED, on SDK `main` (v2.5.0).

An application that opens the `"lcd"` device, reads the geometry with `RTGRAPHIC_CTRL_GET_INFO`, renders an RGB565 framebuffer in PSRAM and pushes it with:

```c
struct rt_device_graphic_ops *ops = rt_graphix_ops(lcd);
ops->set_window(0, 0, w - 1, h - 1);
ops->draw_rect((const char *)fb, 0, 0, w - 1, h - 1);
```

- **before this change:** asserts in `HAL_LCDC_GetPixelSize()` on the first frame, `lcd_task` dies;
- **after this change:** the frame renders correctly, and repeated frames keep working.

Also re-checked the `SF_GRAPHIC_CTRL_LCDC_FLUSH` path on the same board after the change — unaffected.
